### PR TITLE
Python 3 compatibility, update to current KeePass.

### DIFF
--- a/libkeepass/__init__.py
+++ b/libkeepass/__init__.py
@@ -2,16 +2,14 @@
 import io
 from contextlib import contextmanager
 
-from common import read_signature
-from kdb3 import KDB3Reader, KDB3_SIGNATURE
-from kdb4 import KDB4Reader, KDB4_SIGNATURE
+import libkeepass.common, libkeepass.kdb3, libkeepass.kdb4
 
 BASE_SIGNATURE = 0x9AA2D903
 
 _kdb_readers = {
-    KDB3_SIGNATURE[1]: KDB3Reader,
+    kdb3.KDB3_SIGNATURE[1]: kdb3.KDB3Reader,
     #0xB54BFB66: KDB4Reader, # pre2.x may work, untested
-    KDB4_SIGNATURE[1]: KDB4Reader,
+    kdb4.KDB4_SIGNATURE[1]: kdb4.KDB4Reader,
     }
 
 @contextmanager
@@ -28,7 +26,7 @@ def open(filename, **credentials):
     kdb = None
     try:
         with io.open(filename, 'rb') as stream:
-            signature = read_signature(stream)
+            signature = common.read_signature(stream)
             cls = get_kdb_reader(signature)
             kdb = cls(stream, **credentials)
             yield kdb

--- a/libkeepass/crypto.py
+++ b/libkeepass/crypto.py
@@ -2,13 +2,12 @@
 import hashlib
 import struct
 from Crypto.Cipher import AES
-from pureSalsa20 import Salsa20
 
 AES_BLOCK_SIZE = 16
 
 def sha256(s):
     """Return SHA256 digest of the string `s`."""
-    return hashlib.sha256(s).digest()
+    return bytes(hashlib.sha256(s).digest())
 
 def transform_key(key, seed, rounds):
     """Transform `key` with `seed` `rounds` times using AES ECB."""
@@ -30,8 +29,7 @@ def aes_cbc_encrypt(data, key, enc_iv):
     return cipher.encrypt(data)
 
 def unpad(data):
-    extra = ord(data[-1])
-    return data[:len(data)-extra]
+    return data[:len(data)-bytearray(data)[-1]]
 
 def pad(s):
     n = AES_BLOCK_SIZE - len(s) % AES_BLOCK_SIZE

--- a/libkeepass/hbio.py
+++ b/libkeepass/hbio.py
@@ -101,7 +101,7 @@ class HashedBlockIO(io.BytesIO):
                 index += 1
             else:
                 stream.write(struct.pack('<I', index))
-                stream.write('\x00'*32)
+                stream.write(b'\x00'*32)
                 stream.write(struct.pack('<I', 0))
                 break
 

--- a/libkeepass/kdb3.py
+++ b/libkeepass/kdb3.py
@@ -6,11 +6,11 @@ import struct
 import hashlib
 import base64
 
-from crypto import xor, sha256, aes_cbc_decrypt
-from crypto import transform_key, unpad
+from libkeepass.crypto import xor, sha256, aes_cbc_decrypt
+from libkeepass.crypto import transform_key, unpad
 
-from common import load_keyfile, stream_unpack
-from common import KDBFile, HeaderDictionary
+from libkeepass.common import load_keyfile, stream_unpack
+from libkeepass.common import KDBFile, HeaderDictionary
 
 
 KDB3_SIGNATURE = (0x9AA2D903, 0xB54BFB65)

--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,6 @@ setup(
     license = "GPL",
     keywords = "keepass library",
     url = "https://github.com/phpwutz/libkeepass",   # project home page, if any
-    install_requires=["lxml==3.2.1", "nose==1.3.0", "pycrypto==2.6.1"],
+    install_requires=["lxml==3.2.1", "nose==1.3.0", "pycrypto==2.6.1", "salsa20==0.3.0"],
     test_suite="tests"
 )

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
-import os
+import sys, os
 import sys
 import unittest
 
-import libkeepass
+import libkeepass, libkeepass.common, libkeepass.kdb4, libkeepass.kdb3
 
 sys.path.append(os.path.abspath("."))
 sys.path.append(os.path.abspath(".."))
@@ -13,58 +13,55 @@ from libkeepass.crypto import AES_BLOCK_SIZE
 
 class TextCrypto(unittest.TestCase):
     def test_sha256(self):
-        self.assertEquals(sha256(''),
-            "\xe3\xb0\xc4B\x98\xfc\x1c\x14\x9a\xfb\xf4\xc8\x99o\xb9$'\xaeA"
-            "\xe4d\x9b\x93L\xa4\x95\x99\x1bxR\xb8U")
-        self.assertEquals(len(sha256('')), 32)
-        self.assertEquals(len(sha256('asdf')), 32)
+        self.assertEquals(sha256(b''),
+            b"\xe3\xb0\xc4B\x98\xfc\x1c\x14\x9a\xfb\xf4\xc8\x99o\xb9$'\xaeA"
+            b"\xe4d\x9b\x93L\xa4\x95\x99\x1bxR\xb8U")
+        self.assertEquals(len(sha256(b'')), 32)
+        self.assertEquals(len(sha256(b'asdf')), 32)
 
     def test_transform_key(self):
-        self.assertEquals(transform_key(sha256('a'), sha256('b'), 1),
-            '"$\xe6\x83\xb7\xbf\xa9|\x82W\x01J\xce=\xaa\x8d{\x18\x99|0\x1f'
-            '\xbbLT4"F\x83\xd0\xc8\xf9')
-        self.assertEquals(transform_key(sha256('a'), sha256('b'), 2000),
-            '@\xe5Y\x98\xf7\x97$\x0b\x91!\xbefX\xe8\xb6\xbb\t\xefX>\xb3E\x85'
-            '\xedz\x15\x9c\x96\x03K\x8a\xa1')
+        self.assertEquals(transform_key(sha256(b'a'), sha256(b'b'), 1),
+            b'"$\xe6\x83\xb7\xbf\xa9|\x82W\x01J\xce=\xaa\x8d{\x18\x99|0\x1f'
+            b'\xbbLT4"F\x83\xd0\xc8\xf9')
+        self.assertEquals(transform_key(sha256(b'a'), sha256(b'b'), 2000),
+            b'@\xe5Y\x98\xf7\x97$\x0b\x91!\xbefX\xe8\xb6\xbb\t\xefX>\xb3E\x85'
+            b'\xedz\x15\x9c\x96\x03K\x8a\xa1')
 
     def test_aes_cbc_decrypt(self):
-        self.assertEquals(aes_cbc_decrypt('datamustbe16byte', sha256('b'),
+        self.assertEquals(aes_cbc_decrypt('datamustbe16byte', sha256(b'b'),
             'ivmustbe16bytesl'),
-            'x]\xb5\xa6\xe3\x10\xf4\x88\x91_\x03\xc6\xb9\xfb`)')
-        self.assertEquals(aes_cbc_decrypt('datamustbe16byte', sha256('c'),
+            b'x]\xb5\xa6\xe3\x10\xf4\x88\x91_\x03\xc6\xb9\xfb`)')
+        self.assertEquals(aes_cbc_decrypt('datamustbe16byte', sha256(b'c'),
             'ivmustbe16bytesl'),
-            '\x06\x91 \xd9\\\xd8\x14\xa0\xdc\xd7\x82\xa0\x92\xfb\xe8l')
+            b'\x06\x91 \xd9\\\xd8\x14\xa0\xdc\xd7\x82\xa0\x92\xfb\xe8l')
 
     def test_xor(self):
-        self.assertEquals(xor('', ''), '')
-        self.assertEquals(xor('\x00', '\x00'), '\x00')
-        self.assertEquals(xor('\x01', '\x00'), '\x01')
-        self.assertEquals(xor('\x01\x01', '\x00\x01'), '\x01\x00')
-        self.assertEquals(xor('banana', 'ananas'), '\x03\x0f\x0f\x0f\x0f\x12')
+        self.assertEquals(xor(b'', b''), b'')
+        self.assertEquals(xor(b'\x00', b'\x00'), b'\x00')
+        self.assertEquals(xor(b'\x01', b'\x00'), b'\x01')
+        self.assertEquals(xor(b'\x01\x01', b'\x00\x01'), b'\x01\x00')
+        self.assertEquals(xor(b'banana', b'ananas'), b'\x03\x0f\x0f\x0f\x0f\x12')
 
     def test_pad(self):
-        self.assertEquals(pad(''),
-            '\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10')
-        self.assertEquals(pad('\xff'),
-            '\xff\x0f\x0f\x0f\x0f\x0f\x0f\x0f\x0f\x0f\x0f\x0f\x0f\x0f\x0f\x0f')
-        self.assertEquals(pad('\xff\xff'),
-            '\xff\xff\x0e\x0e\x0e\x0e\x0e\x0e\x0e\x0e\x0e\x0e\x0e\x0e\x0e\x0e')
-        self.assertEquals(pad('\xff\xff\xff'),
-            '\xff\xff\xff\x0d\x0d\x0d\x0d\x0d\x0d\x0d\x0d\x0d\x0d\x0d\x0d\x0d')
-        self.assertEquals(pad('\xff\xff\xff\xff'),
-            '\xff\xff\xff\xff\x0c\x0c\x0c\x0c\x0c\x0c\x0c\x0c\x0c\x0c\x0c\x0c')
-        self.assertEquals(pad('\xff\xff\xff\xff\xff'),
-            '\xff\xff\xff\xff\xff\x0b\x0b\x0b\x0b\x0b\x0b\x0b\x0b\x0b\x0b\x0b')
-        self.assertEquals(len(pad('\xff')), AES_BLOCK_SIZE)
-        self.assertEquals(len(pad('\xff'*0)), AES_BLOCK_SIZE)
-        self.assertEquals(len(pad('\xff'*1)), AES_BLOCK_SIZE)
-        self.assertEquals(len(pad('\xff'*2)), AES_BLOCK_SIZE)
-        self.assertEquals(len(pad('\xff'*15)), AES_BLOCK_SIZE)
-        self.assertEquals(len(pad('\xff'*16)), 2*AES_BLOCK_SIZE)
-        self.assertEquals(len(pad('\xff'*17)), 2*AES_BLOCK_SIZE)
-
-
-import keepass
+        self.assertEquals(pad(b''),
+            b'\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10')
+        self.assertEquals(pad(b'\xff'),
+            b'\xff\x0f\x0f\x0f\x0f\x0f\x0f\x0f\x0f\x0f\x0f\x0f\x0f\x0f\x0f\x0f')
+        self.assertEquals(pad(b'\xff\xff'),
+            b'\xff\xff\x0e\x0e\x0e\x0e\x0e\x0e\x0e\x0e\x0e\x0e\x0e\x0e\x0e\x0e')
+        self.assertEquals(pad(b'\xff\xff\xff'),
+            b'\xff\xff\xff\x0d\x0d\x0d\x0d\x0d\x0d\x0d\x0d\x0d\x0d\x0d\x0d\x0d')
+        self.assertEquals(pad(b'\xff\xff\xff\xff'),
+            b'\xff\xff\xff\xff\x0c\x0c\x0c\x0c\x0c\x0c\x0c\x0c\x0c\x0c\x0c\x0c')
+        self.assertEquals(pad(b'\xff\xff\xff\xff\xff'),
+            b'\xff\xff\xff\xff\xff\x0b\x0b\x0b\x0b\x0b\x0b\x0b\x0b\x0b\x0b\x0b')
+        self.assertEquals(len(pad(b'\xff')), AES_BLOCK_SIZE)
+        self.assertEquals(len(pad(b'\xff'*0)), AES_BLOCK_SIZE)
+        self.assertEquals(len(pad(b'\xff'*1)), AES_BLOCK_SIZE)
+        self.assertEquals(len(pad(b'\xff'*2)), AES_BLOCK_SIZE)
+        self.assertEquals(len(pad(b'\xff'*15)), AES_BLOCK_SIZE)
+        self.assertEquals(len(pad(b'\xff'*16)), 2*AES_BLOCK_SIZE)
+        self.assertEquals(len(pad(b'\xff'*17)), 2*AES_BLOCK_SIZE)
 
 
 class TestModule(unittest.TestCase):
@@ -146,41 +143,41 @@ class TestCommon(unittest.TestCase):
         h.fmt[4] = '<q'
         h[4] = 3000
         self.assertEquals(h.rounds, 3000)
-        self.assertEquals(h.b.rounds, '\xb8\x0b\x00\x00\x00\x00\x00\x00')
-        self.assertEquals(h.b['rounds'], '\xb8\x0b\x00\x00\x00\x00\x00\x00')
-        self.assertEquals(h.b[4], '\xb8\x0b\x00\x00\x00\x00\x00\x00')
+        self.assertEquals(h.b.rounds, b'\xb8\x0b\x00\x00\x00\x00\x00\x00')
+        self.assertEquals(h.b['rounds'], b'\xb8\x0b\x00\x00\x00\x00\x00\x00')
+        self.assertEquals(h.b[4], b'\xb8\x0b\x00\x00\x00\x00\x00\x00')
         h['rounds'] = 3001
         self.assertEquals(h.rounds, 3001)
-        self.assertEquals(h.b.rounds, '\xb9\x0b\x00\x00\x00\x00\x00\x00')
-        self.assertEquals(h.b['rounds'], '\xb9\x0b\x00\x00\x00\x00\x00\x00')
-        self.assertEquals(h.b[4], '\xb9\x0b\x00\x00\x00\x00\x00\x00')
+        self.assertEquals(h.b.rounds, b'\xb9\x0b\x00\x00\x00\x00\x00\x00')
+        self.assertEquals(h.b['rounds'], b'\xb9\x0b\x00\x00\x00\x00\x00\x00')
+        self.assertEquals(h.b[4], b'\xb9\x0b\x00\x00\x00\x00\x00\x00')
         h.rounds = 3002
         self.assertEquals(h.rounds, 3002)
-        self.assertEquals(h.b.rounds, '\xba\x0b\x00\x00\x00\x00\x00\x00')
-        self.assertEquals(h.b['rounds'], '\xba\x0b\x00\x00\x00\x00\x00\x00')
-        self.assertEquals(h.b[4], '\xba\x0b\x00\x00\x00\x00\x00\x00')
+        self.assertEquals(h.b.rounds, b'\xba\x0b\x00\x00\x00\x00\x00\x00')
+        self.assertEquals(h.b['rounds'], b'\xba\x0b\x00\x00\x00\x00\x00\x00')
+        self.assertEquals(h.b[4], b'\xba\x0b\x00\x00\x00\x00\x00\x00')
 
-        h.b[4] = '\x70\x17\x00\x00\x00\x00\x00\x00'
+        h.b[4] = b'\x70\x17\x00\x00\x00\x00\x00\x00'
         self.assertEquals(h.rounds, 6000)
-        self.assertEquals(h.b.rounds, '\x70\x17\x00\x00\x00\x00\x00\x00')
-        self.assertEquals(h.b['rounds'], '\x70\x17\x00\x00\x00\x00\x00\x00')
-        self.assertEquals(h.b[4], '\x70\x17\x00\x00\x00\x00\x00\x00')
-        h.b['rounds'] = '\x71\x17\x00\x00\x00\x00\x00\x00'
+        self.assertEquals(h.b.rounds, b'\x70\x17\x00\x00\x00\x00\x00\x00')
+        self.assertEquals(h.b['rounds'], b'\x70\x17\x00\x00\x00\x00\x00\x00')
+        self.assertEquals(h.b[4], b'\x70\x17\x00\x00\x00\x00\x00\x00')
+        h.b['rounds'] = b'\x71\x17\x00\x00\x00\x00\x00\x00'
         self.assertEquals(h.rounds, 6001)
-        self.assertEquals(h.b.rounds, '\x71\x17\x00\x00\x00\x00\x00\x00')
-        self.assertEquals(h.b['rounds'], '\x71\x17\x00\x00\x00\x00\x00\x00')
-        self.assertEquals(h.b[4], '\x71\x17\x00\x00\x00\x00\x00\x00')
-        h.b.rounds = '\x72\x17\x00\x00\x00\x00\x00\x00'
+        self.assertEquals(h.b.rounds, b'\x71\x17\x00\x00\x00\x00\x00\x00')
+        self.assertEquals(h.b['rounds'], b'\x71\x17\x00\x00\x00\x00\x00\x00')
+        self.assertEquals(h.b[4], b'\x71\x17\x00\x00\x00\x00\x00\x00')
+        h.b.rounds = b'\x72\x17\x00\x00\x00\x00\x00\x00'
         self.assertEquals(h.rounds, 6002)
-        self.assertEquals(h.b.rounds, '\x72\x17\x00\x00\x00\x00\x00\x00')
-        self.assertEquals(h.b['rounds'], '\x72\x17\x00\x00\x00\x00\x00\x00')
-        self.assertEquals(h.b[4], '\x72\x17\x00\x00\x00\x00\x00\x00')
+        self.assertEquals(h.b.rounds, b'\x72\x17\x00\x00\x00\x00\x00\x00')
+        self.assertEquals(h.b['rounds'], b'\x72\x17\x00\x00\x00\x00\x00\x00')
+        self.assertEquals(h.b[4], b'\x72\x17\x00\x00\x00\x00\x00\x00')
 
         # raw interface without conversation
         h.fields['hash'] = 5
-        h.hash = '\x91.\xc8\x03\xb2\xceI\xe4\xa5A\x06\x8dIZ'
-        self.assertEquals(h.hash, '\x91.\xc8\x03\xb2\xceI\xe4\xa5A\x06\x8dIZ')
-        self.assertEquals(h.b.hash, '\x91.\xc8\x03\xb2\xceI\xe4\xa5A\x06\x8dIZ')
+        h.hash = b'\x91.\xc8\x03\xb2\xceI\xe4\xa5A\x06\x8dIZ'
+        self.assertEquals(h.hash, b'\x91.\xc8\x03\xb2\xceI\xe4\xa5A\x06\x8dIZ')
+        self.assertEquals(h.b.hash, b'\x91.\xc8\x03\xb2\xceI\xe4\xa5A\x06\x8dIZ')
         #assert False
 
 # created with KeePassX 0.4.3
@@ -203,7 +200,7 @@ class TestKDB4(unittest.TestCase):
 
     def test_class_interface(self):
         """Test direct KDB4Reader class usage"""
-        kdb = libkeepass.KDB4Reader()
+        kdb = libkeepass.kdb4.KDB4Reader()
         with self.assertRaisesRegexp(TypeError, "Stream does not have the buffer interface."):
             kdb.read_from(absfile1)
         with self.assertRaisesRegexp(IndexError, "No credentials found."):
@@ -213,29 +210,29 @@ class TestKDB4(unittest.TestCase):
         with open(absfile1, 'rb') as fh:
             kdb.read_from(fh)
         self.assertEquals(kdb.opened, True)
-        self.assertEquals(kdb.read(32), '<?xml version="1.0" encoding="ut')
+        self.assertEquals(kdb.read(32), b'<?xml version="1.0" encoding="ut')
 
     def test_write_file(self):
         # valid password and plain keyfile, compressed kdb
         with libkeepass.open(absfile1, password="asdf") as kdb:
             self.assertEquals(kdb.opened, True)
-            self.assertEquals(kdb.read(32), '<?xml version="1.0" encoding="ut')
+            self.assertEquals(kdb.read(32), b'<?xml version="1.0" encoding="ut')
             kdb.set_compression(0)
             #kdb.set_comment("this is pretty cool!")
             kdb.clear_credentials()
             kdb.add_credentials(password="yxcv")
-            with open(output1, 'w') as outfile:
+            with open(output1, 'wb') as outfile:
                 kdb.write_to(outfile)
         with libkeepass.open(output1, password="yxcv") as kdb:
-            self.assertEquals(kdb.read(32), "<?xml version='1.0' encoding='ut")
+            self.assertEquals(kdb.read(32), b"<?xml version='1.0' encoding='ut")
 
         with libkeepass.open(absfile4, password="qwer", keyfile=keyfile4) as kdb:
             self.assertEquals(kdb.opened, True)
-            self.assertEquals(kdb.read(32), '<?xml version="1.0" encoding="ut')
-            with open(output4, 'w') as outfile:
+            self.assertEquals(kdb.read(32), b'<?xml version="1.0" encoding="ut')
+            with open(output4, 'wb') as outfile:
                 kdb.write_to(outfile)
         with libkeepass.open(output4, password="qwer", keyfile=keyfile4) as kdb:
-            self.assertEquals(kdb.read(32), "<?xml version='1.0' encoding='ut")
+            self.assertEquals(kdb.read(32), b"<?xml version='1.0' encoding='ut")
 
     def test_open_file(self):
         # file not found, proper exception gets re-raised
@@ -282,9 +279,9 @@ class TestKDB4(unittest.TestCase):
             tmp1 = kdb.read(32)
             tmp2 = kdb.read(32)
             self.assertIsNotNone(tmp1)
-            self.assertEquals(tmp1, '<?xml version="1.0" encoding="ut')
+            self.assertEquals(tmp1, b'<?xml version="1.0" encoding="ut')
             self.assertIsNotNone(tmp2)
-            self.assertEquals(tmp2, 'f-8" standalone="yes"?>\n<KeePass')
+            self.assertEquals(tmp2, b'f-8" standalone="yes"?>\n<KeePass')
             self.assertNotEquals(tmp1, tmp2)
             self.assertEquals(kdb.tell(), 64)
             kdb.seek(0)


### PR DESCRIPTION
Hi, I've fixed some issues while trying to get this to work at all and on Python 3 as well. The 'at all' is related to Salsa20, which I couldn't find in a released version of pycrypto. Therefore I replaced that with a dependency on python-salsa20, which in contrast to the former library is released. The Python 3 part relates to many different things, see below. Test cases run through on Python 2 and 3 and I've run loading/saving on a moderate size real database as well, which had the same XML output after saving to a new file and same header/hash. However the files differ after compression and encryption, so the difference there is something I still want to investigate to get closer to the original output.

If the Salsa20 dependency is somehow (I don't see how?) unnecessary I'd remove it again, but it seems to me this way would be the easiest.

My next step (and original goal) would be merging of files, so I'll be looking into the original sources to be compatible to the handling there.

Cheers,
Olof
