### PR TITLE
Allow protected loading of keepass Vaults

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -80,6 +80,16 @@ Examples
        # write to a new file
        with open('output', 'wb') as output:
            kdb.write_to(output)
+           
+   # Alternatively, read a kdb4 file protected
+   with libkeepass.open(filename, password='secret', keyfile='putty.exe', unprotect=False) as kdb:
+       # print parsed element tree as xml
+       print kdb.pretty_print()
+
+       # decrypt the password fields
+       kdb.unprotect()
+       print kdb.pretty_print()
+
 
 Testing
 -------

--- a/libkeepass/common.py
+++ b/libkeepass/common.py
@@ -127,7 +127,7 @@ from libkeepass.crypto import sha256
 
 
 class KDBFile(object):
-    def __init__(self, stream=None, **credentials):
+    def __init__(self, stream=None, unprotect=True, **credentials):
         # list of hashed credentials (pre-transformation)
         self.keys = []
         self.add_credentials(**credentials)
@@ -146,7 +146,7 @@ class KDBFile(object):
 
         # the raw/basic file handle, expect it to be closed after __init__!
         if stream is not None:
-            self.read_from(stream)
+            self.read_from(stream, unprotect)
 
     def _is_file(self, stream):
         if isinstance(stream, io.IOBase):

--- a/libkeepass/kdb3.py
+++ b/libkeepass/kdb3.py
@@ -418,7 +418,7 @@ class KDB3Reader(KDB3File, KDBExtension):
     def __init__(self, stream=None, **credentials):
         KDB3File.__init__(self, stream, **credentials)
 
-    def read_from(self, stream, **options):
+    def read_from(self, stream, unprotect=True):
         KDB3File.read_from(self, stream)
         # the extension requires parsed header and decrypted self.in_buffer, so
         # initialize only here

--- a/libkeepass/kdb3.py
+++ b/libkeepass/kdb3.py
@@ -418,7 +418,7 @@ class KDB3Reader(KDB3File, KDBExtension):
     def __init__(self, stream=None, **credentials):
         KDB3File.__init__(self, stream, **credentials)
 
-    def read_from(self, stream):
+    def read_from(self, stream, **options):
         KDB3File.read_from(self, stream)
         # the extension requires parsed header and decrypted self.in_buffer, so
         # initialize only here

--- a/libkeepass/kdb3.py
+++ b/libkeepass/kdb3.py
@@ -7,6 +7,7 @@ import hashlib
 import base64
 import random
 import datetime
+import warnings
 from binascii import * # for entry id
 
 from libkeepass.crypto import xor, sha256, aes_cbc_decrypt
@@ -419,6 +420,8 @@ class KDB3Reader(KDB3File, KDBExtension):
         KDB3File.__init__(self, stream, **credentials)
 
     def read_from(self, stream, unprotect=True):
+        if not unprotect:
+            warnings.warn("KDB3 files do not support protected reading, the keyword will be ignored.")        
         KDB3File.read_from(self, stream)
         # the extension requires parsed header and decrypted self.in_buffer, so
         # initialize only here

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -307,6 +307,28 @@ class TestKDB4(unittest.TestCase):
 
             self.assertIsNotNone(kdb.pretty_print())
 
+		# unprotect=False
+        with libkeepass.open(absfile4, password="qwer", 
+									keyfile=keyfile4, unprotect=False) as kdb:
+            self.assertIsNotNone(kdb)
+            self.assertEqual(kdb.opened, True)
+            self.assertIsInstance(kdb, libkeepass.kdb4.KDB4Reader)
+
+            # read xml
+            # Copy the value since unprotect would change it otherwise
+            xml1 = str(kdb.obj_root.Root.Group.Entry.String[1].Value) 
+            self.assertNotEqual(xml1, "Password")
+            kdb.unprotect()  # make passwords clear
+            xml2 = kdb.obj_root.Root.Group.Entry.String[1].Value.get('ProtectedValue')
+            self.assertEqual(xml1, xml2)
+            xml3 = kdb.obj_root.Root.Group.Entry.String[1].Value
+            self.assertEqual(xml3, "Password")
+            kdb.protect()  # and re-encrypt protected values again
+            xml4 = kdb.obj_root.Root.Group.Entry.String[1].Value
+            self.assertEqual(xml1, xml4)
+
+            self.assertIsNotNone(kdb.pretty_print())
+
         # twofish encryption
         with libkeepass.open(absfile6, password="qwerty") as kdb:
             self.assertIsNotNone(kdb)

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -3,6 +3,7 @@ import os
 import sys
 import datetime
 import unittest
+import warnings
 
 import libkeepass
 import libkeepass.common
@@ -318,6 +319,16 @@ class TestKDB3(unittest.TestCase):
             self.assertIsNotNone(kdb)
             self.assertEqual(kdb.opened, True)
             self.assertIsInstance(kdb, libkeepass.kdb3.KDB3Reader)
+
+    def test_open_file_protected(self):
+        # old kdb file
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            with libkeepass.open(absfile2, password="asdf", unprotect=False) as kdb:
+                self.assertIsNotNone(kdb)
+            self.assertEqual(w[0].category, UserWarning)
+            self.assertTrue("KDB3 files do not support protected reading, " \
+							"the keyword will be ignored." in str(w[0].message))
 
     def test_verify_kdb3(self):
         with libkeepass.open(absfile2, password="asdf") as kdb:


### PR DESCRIPTION
This PR exposed the internal options of reading from a keepass file v4 without unprotecting the password fields to the outside API. A small adjustment needed to be made to kdb3 files since they do not offer this option (the tests are still passing with these changes).

Do you think this is a sensible change?