### PR TITLE
Add option to write to kdbx databases

### DIFF
--- a/libkeepass/__init__.py
+++ b/libkeepass/__init__.py
@@ -24,7 +24,7 @@ _kdb_readers = {
 }
 
 @contextmanager
-def open(filename, **credentials):
+def open(filename, mode='rb+', **credentials):
     """
     A contextmanager to open the KeePass file with `filename`. Use a `password`
     and/or `keyfile` named argument for decryption.
@@ -36,7 +36,7 @@ def open(filename, **credentials):
     """
     kdb = None
     try:
-        with io.open(filename, 'rb') as stream:
+        with io.open(filename, mode) as stream:
             signature = common.read_signature(stream)
             cls = get_kdb_reader(signature)
             kdb = cls(stream, **credentials)


### PR DESCRIPTION
Sometimes, we need to write to kdbx file. This library doesn't allow this ability without having to declare yet another file descriptor, just to be able to write.

This patch adds the ability to reuse the existing file descriptor opened in `pykeepass`'s `open` context manager.