### PR TITLE
Fix python3 detection

### DIFF
--- a/libkeepass/kdb4.py
+++ b/libkeepass/kdb4.py
@@ -90,7 +90,7 @@ class KDB4File(KDBFile):
         
         :arg stream: A writeable file-like object or IO buffer.
         """
-        if not (isinstance(stream, io.IOBase) or isinstance(stream, file)):
+        if not _is_file(stream):
             raise TypeError('Stream does not have the buffer interface.')
 
         self._write_header(stream)


### PR DESCRIPTION
The second condition shouldn't be checked when we are using Python 3, as that version of the language doesn't have the `file` type. Fix that.