### PR TITLE
from __future__ import print_function for Python 2

### DIFF
--- a/samples/prettyprint.py
+++ b/samples/prettyprint.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+from __future__ import print_function
 import libkeepass
 import getpass
 import sys
@@ -16,4 +17,3 @@ try:
 except Exception as e:
     print('Could not prettyprint KeePass Database %s:\n%s' % (filename, str(e)), file=sys.stderr)
     sys.exit(2)
-

--- a/samples/query.py
+++ b/samples/query.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+from __future__ import print_function
 import libkeepass
 import getpass
 import sys


### PR DESCRIPTION
Without these changes, Python 2 sees print('xyz', __file=__sys.stderr) as a SyntaxError.