### PR TITLE
Resolve five undefined names

### DIFF
--- a/libkeepass/__init__.py
+++ b/libkeepass/__init__.py
@@ -36,7 +36,7 @@ def open(filename, **credentials):
     """
     kdb = None
     try:
-        with io.open(filename, 'rb') as stream:
+        with io.open(filename, mode) as stream:
             signature = libkeepass.common.read_signature(stream)
             cls = get_kdb_reader(signature)
             kdb = cls(stream, **credentials)

--- a/libkeepass/__init__.py
+++ b/libkeepass/__init__.py
@@ -18,9 +18,9 @@ import libkeepass.kdb4
 BASE_SIGNATURE = 0x9AA2D903
 
 _kdb_readers = {
-    kdb3.KDB3_SIGNATURE[1]: kdb3.KDB3Reader,
+    libkeepass.kdb3.KDB3_SIGNATURE[1]: libkeepass.kdb3.KDB3Reader,
     # 0xB54BFB66: KDB4Reader, # pre2.x may work, untested
-    kdb4.KDB4_SIGNATURE[1]: kdb4.KDB4Reader,
+    libkeepass.kdb4.KDB4_SIGNATURE[1]: libkeepass.kdb4.KDB4Reader,
 }
 
 @contextmanager
@@ -37,7 +37,7 @@ def open(filename, **credentials):
     kdb = None
     try:
         with io.open(filename, 'rb') as stream:
-            signature = common.read_signature(stream)
+            signature = libkeepass.common.read_signature(stream)
             cls = get_kdb_reader(signature)
             kdb = cls(stream, **credentials)
             yield kdb


### PR DESCRIPTION
flake8 testing of https://github.com/libkeepass/libkeepass on Python 2.7.13

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./libkeepass/__init__.py:21:5: F821 undefined name 'kdb3'
    kdb3.KDB3_SIGNATURE[1]: kdb3.KDB3Reader,
    ^

./libkeepass/__init__.py:21:29: F821 undefined name 'kdb3'
    kdb3.KDB3_SIGNATURE[1]: kdb3.KDB3Reader,
                            ^

./libkeepass/__init__.py:23:5: F821 undefined name 'kdb4'
    kdb4.KDB4_SIGNATURE[1]: kdb4.KDB4Reader,
    ^

./libkeepass/__init__.py:23:29: F821 undefined name 'kdb4'
    kdb4.KDB4_SIGNATURE[1]: kdb4.KDB4Reader,
                            ^

./libkeepass/__init__.py:40:25: F821 undefined name 'common'
            signature = common.read_signature(stream)
                        ^
```