### PR TITLE
Method is on parent, fix that

### DIFF
--- a/libkeepass/kdb4.py
+++ b/libkeepass/kdb4.py
@@ -90,7 +90,7 @@ class KDB4File(KDBFile):
         
         :arg stream: A writeable file-like object or IO buffer.
         """
-        if not _is_file(stream):
+        if not self._is_file(stream):
             raise TypeError('Stream does not have the buffer interface.')
 
         self._write_header(stream)


### PR DESCRIPTION
[This push request](https://github.com/libkeepass/libkeepass/pull/6) introduced an issue. The method `is_file` must be called on the parent and is not available in the child (current) class, causing an issue.

```
Traceback (most recent call last):
  File "./libo_to_keepass.py", line 331, in <module>
    main()
  File "./libo_to_keepass.py", line 297, in main
    kp.save(group, entries_to_add)
  File "./libo_to_keepass.py", line 117, in save
    self.kdb.write_to(outfile)
  File ".//libkeepass/kdb4.py", line 439, in write_to
    KDB4File.write_to(self, stream)
  File "./libkeepass/kdb4.py", line 93, in write_to
    if not _is_file(stream):
```

Sorry about that.