### PR TITLE
Remove twofish support because of outdated CryptoPlus library

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -19,7 +19,6 @@ Dependencies
 
 - pycrypto
 - lxml
-- CryptoPlus (optional - adds twofish encryption support for v1 databases)
 
 KeePass 1.x support
 -------------------
@@ -32,6 +31,8 @@ entries are not parsed and seen as regular entries.
 Only passwords are supported.
 
 No write support.
+
+No Twofish encryption support.
 
 KeePass 2.x support
 -------------------
@@ -51,7 +52,8 @@ There is basic "save as" write support. When writing the KeePass2 file, the
 element tree is protected, serialized, compressed and encrypted according to the
 settings in the file header and written to a stream.
 
-Currently the ChaCha20 encryption algorithm and Argon2 key derivation algorithm are unsupported.
+Currently the Twofish, the ChaCha20 encryption algorithm and Argon2 key
+derivation algorithm are unsupported.
 
 Examples
 --------

--- a/libkeepass/crypto.py
+++ b/libkeepass/crypto.py
@@ -2,14 +2,6 @@
 import hashlib
 import struct
 from Crypto.Cipher import AES
-try:
-    from CryptoPlus.Cipher import python_Twofish
-except ImportError:
-    class _python_Twofish(object):
-            def __getattribute__(self, k):
-                raise IOError("The support library for this encryption method (twofish) is not installed.  Run `pip install \'https://github.com/doegox/python-cryptoplus/tarball/python3\'`")
-    python_Twofish = _python_Twofish()
-
 from libkeepass.pureSalsa20 import Salsa20
 
 AES_BLOCK_SIZE = 16
@@ -40,18 +32,6 @@ def aes_cbc_decrypt(data, key, enc_iv):
 def aes_cbc_encrypt(data, key, enc_iv):
     """Encrypt and return `data` with AES CBC."""
     cipher = AES.new(key, AES.MODE_CBC, enc_iv)
-    return cipher.encrypt(data)
-
-
-def twofish_cbc_decrypt(data, key, enc_iv):
-    """Decrypt and return `data` with Twofish CBC."""
-    cipher = python_Twofish.new(key, python_Twofish.MODE_CBC, enc_iv)
-    return cipher.decrypt(data)
-
-
-def twofish_cbc_encrypt(data, key, enc_iv):
-    """Encrypt and return `data` with Twofish CBC."""
-    cipher = python_Twofish.new(key, python_Twofish.MODE_CBC, enc_iv)
     return cipher.encrypt(data)
 
 

--- a/libkeepass/kdb3.py
+++ b/libkeepass/kdb3.py
@@ -94,9 +94,8 @@ class KDB3File(KDBFile):
                                self.header.EncryptionIV)
             data = unpad(data)
         elif self.header.encryption_flags[self.header.Flags-1] == 'Twofish':
-            data = twofish_cbc_decrypt(stream.read(), self.master_key,
-                               self.header.EncryptionIV)
-            data = unpad(data)
+            # TODO next release - remove this elif and Twofish from encryption_flags
+            raise IOError('Twofish encryption is no longer supported by libkeepass')
         else:
             raise IOError('Unsupported encryption type: %s'%self.header.encryption_flags.get(self.header['Flags']-1, self.header['Flags']-1))
 

--- a/libkeepass/kdb4.py
+++ b/libkeepass/kdb4.py
@@ -9,7 +9,6 @@ import base64
 import codecs
 
 from libkeepass.crypto import xor, sha256, aes_cbc_decrypt, aes_cbc_encrypt
-from libkeepass.crypto import twofish_cbc_decrypt, twofish_cbc_encrypt
 from libkeepass.crypto import transform_key, pad, unpad
 
 from libkeepass.common import load_keyfile, stream_unpack
@@ -198,9 +197,8 @@ class KDB4File(KDBFile):
                                    self.header.EncryptionIV)
             data = unpad(data)
         elif ciphername == 'Twofish':
-            data = twofish_cbc_decrypt(stream.read(), self.master_key,
-                                   self.header.EncryptionIV)
-            data = unpad(data)
+            # TODO next release - remove this elif and Twofish from ciphers
+            raise IOError('Twofish encryption is no longer supported by libkeepass')
         else:
             raise IOError('Unsupported decryption type: %s'%codecs.encode(ciphername, 'hex'))
 
@@ -241,9 +239,8 @@ class KDB4File(KDBFile):
             self.out_buffer = aes_cbc_encrypt(data, self.master_key,
                                               self.header.EncryptionIV)
         elif ciphername == 'Twofish':
-            data = pad(self.out_buffer.read())
-            self.out_buffer = twofish_cbc_encrypt(data, self.master_key,
-                                                  self.header.EncryptionIV)
+            # TODO next release - remove this elif and Twofish from ciphers
+            raise IOError('Twofish encryption is no longer supported by libkeepass')
         else:
             raise IOError('Unsupported encryption type: %s'%codecs.encode(ciphername, 'hex'))
 

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -16,7 +16,7 @@ sys.path.append(os.path.abspath("."))
 sys.path.append(os.path.abspath(".."))
 
 from libkeepass.crypto import sha256, transform_key, xor, pad
-from libkeepass.crypto import aes_cbc_decrypt, twofish_cbc_decrypt, twofish_cbc_encrypt
+from libkeepass.crypto import aes_cbc_decrypt
 from libkeepass.crypto import AES_BLOCK_SIZE
 
 
@@ -43,17 +43,6 @@ class TextCrypto(unittest.TestCase):
         self.assertEqual(aes_cbc_decrypt(b'datamustbe16byte', sha256(b'c'),
                                           b'ivmustbe16bytesl'),
                           b'\x06\x91 \xd9\\\xd8\x14\xa0\xdc\xd7\x82\xa0\x92\xfb\xe8l')
-
-    def test_twofish_cbc_decrypt(self):
-        self.assertEqual(twofish_cbc_encrypt(b'datamustbe16byte', sha256(b'b'),
-                                              b'ivmustbe16bytesl'),
-                          b'\xd4^&`\xe1j\xfd{\xeb\x04{\x90f\xed\xebi')
-        self.assertEqual(twofish_cbc_encrypt(b'datamustbe16byte', sha256(b'c'),
-                                              b'ivmustbe16bytesl'),
-                          b'\xb3\x86\xbe\x0ficZW\x92P\xeb\x17\xa8\xa8\xac\xe8')
-        self.assertEqual(twofish_cbc_decrypt(b'K\x07q\xad\xd0\x8d\xb9\x0f\x15\xef\x87\x089\xc3\x83\x9c',
-                                              sha256(b'd'), b'ivmustbe16bytesl'),
-                          b'datamustbe16byte')
 
     def test_xor(self):
         self.assertEqual(xor(b'', b''), b'')
@@ -329,10 +318,12 @@ class TestKDB4(unittest.TestCase):
 
             self.assertIsNotNone(kdb.pretty_print())
 
-        # twofish encryption
-        with libkeepass.open(absfile6, password="qwerty") as kdb:
-            self.assertIsNotNone(kdb)
-            self.assertEqual(kdb.opened, True)
+        # twofish encryption no longer supported
+        with self.assertRaises(IOError,
+                               msg="Twofish encryption is no longer supported by libkeepass"):
+            with libkeepass.open(absfile6, password="qwerty") as kdb:
+                pass
+
 
 class TestKDB3(unittest.TestCase):
     def test_open_file(self):


### PR DESCRIPTION
So, just going off @Evidlo's comment in #12, here's a PR to remove twofish and CryptoPlus support.

I'll leave it to the more experienced members here to decide if that's actually a good idea! Figured I'd supply the grunt work...seemed easy enough.

Thanks!
Scott