### PR TITLE
Improvements

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -78,7 +78,7 @@ Currently 3 merge modes are supported:
 * **OVERWRITE_IF_NEWER** -- Entries are updated if there is a newer one in the
   KDB being merged with and the previous entry is added to the entry history.
   No Entry relocations nor deletions are done.
-* **SYNCHRONIZE** - This mode should be equivalent to the official keepass
+* **SYNCHRONIZE** -- This mode should be equivalent to the official keepass
   *synchronize*, which does and `OVERWRITE_IF_NEWER`, Entry relocations, and
   deletions.
 * **SYNCHRONIZE_3WAY** -- This mode is similar to `SYNCHRONIZE`, except that
@@ -130,6 +130,23 @@ Examples
        # decrypt the password fields
        kdb.unprotect()
        print(kdb.pretty_print())
+
+
+Tools
+-------
+
+**shell** -- Basic command line shell to view a keepass database
+
+**kdbutil** -- Utility to manipulate keepass databases with the following subcommands:
+
+* **convert4** -- Convert a KDB v3 database to v4 format.  This is better than
+  keepassx's (current) importer because it keeps entry uuids unique
+  across multiple conversions of the same KDB v3 database.
+
+* **dump** -- Dump the inner xml of the keepass database.
+  WARNING: This will print passwords in clear-text.
+
+* **shell** -- another simple shell for manipulating keepass database files.
 
 
 Testing

--- a/kdbutil.py
+++ b/kdbutil.py
@@ -136,6 +136,7 @@ def kdbfile_shell(args):
                 print(ex)
     else:
         del creds_list
+        print("Opened kdb files are in the list variable 'kdbfiles'.")
         code.interact(local=dict(kdbfiles=kdbfiles))
 
 def kdbfile_convert4(args):

--- a/libkeepass/__init__.py
+++ b/libkeepass/__init__.py
@@ -2,14 +2,7 @@
 import io
 from contextlib import contextmanager
 
-# Python 2 BytesIO has no getbuffer method
-if not hasattr(io.BytesIO(), 'getbuffer'):
-    class BytesIO(io.BytesIO):
-        def getbuffer(self):
-            return memoryview(self.getvalue())
-    io.BytesIO = BytesIO
-
-
+import libkeepass.compat
 import libkeepass.common
 import libkeepass.kdb3
 import libkeepass.kdb4

--- a/libkeepass/common.py
+++ b/libkeepass/common.py
@@ -144,6 +144,8 @@ class KDBFile(object):
         # encryption masterkey. if this is True `in_buffer` must contain
         # clear data.
         self.opened = False
+        
+        assert self.__class__ != KDBFile, "Must use subclass of KDBFile"
 
         # the raw/basic file handle, expect it to be closed after __init__!
         if stream is not None:

--- a/libkeepass/compat.py
+++ b/libkeepass/compat.py
@@ -1,0 +1,17 @@
+# -*- coding: utf-8 -*-
+# Module for compatibility with python 2.7 and 3.x
+
+from __future__ import print_function
+
+import sys
+import io
+
+IS_PYTHON_3 = sys.hexversion >= 0x3000000
+
+
+# Python 2 BytesIO has no getbuffer method
+if not hasattr(io.BytesIO(), 'getbuffer'):
+    class BytesIO(io.BytesIO):
+        def getbuffer(self):
+            return memoryview(self.getvalue())
+    io.BytesIO = BytesIO

--- a/libkeepass/kdb3.py
+++ b/libkeepass/kdb3.py
@@ -13,7 +13,7 @@ from binascii import * # for entry id
 from libkeepass.crypto import xor, sha256, aes_cbc_decrypt, twofish_cbc_decrypt
 from libkeepass.crypto import transform_key, unpad
 
-from libkeepass.common import IS_PYTHON_3, load_keyfile, stream_unpack
+from libkeepass.common import IS_PYTHON_3, load_keyfile, stream_unpack, read_signature
 from libkeepass.common import KDBFile, HeaderDictionary
 
 
@@ -75,8 +75,10 @@ class KDB3File(KDBFile):
         """
         # kdb3 has a fixed header length
         self.header_length = 124
-        # skip file signature
-        stream.seek(8)
+
+        # verify the file signature
+        signature = read_signature(stream)
+        assert signature == KDB3_SIGNATURE, signature
 
         for field_id, length in enumerate(self.header.lengths):
             data = stream_unpack(stream, None, length, '{}s'.format(length))

--- a/libkeepass/kdb4.py
+++ b/libkeepass/kdb4.py
@@ -126,7 +126,7 @@ class KDB4File(KDBFile):
 
             # field_id >10 is undefined
             if not field_id in self.header.fields.values():
-                raise IOError('Unknown header field found.')
+                raise IOError('Unknown header field %x found.' % field_id)
 
             # two byte (short) length of field data
             if self.file_version < FILEVERSION_4:

--- a/libkeepass/kdb4.py
+++ b/libkeepass/kdb4.py
@@ -13,7 +13,7 @@ from libkeepass.crypto import (xor, sha256, aes_cbc_decrypt, aes_cbc_encrypt,
     twofish_cbc_decrypt, twofish_cbc_encrypt,
     transform_key, pad, unpad)
 
-from libkeepass.common import IS_PYTHON_3, load_keyfile, stream_unpack
+from libkeepass.common import IS_PYTHON_3, load_keyfile, stream_unpack, read_signature
 
 from libkeepass.common import KDBFile, HeaderDictionary
 from libkeepass.hbio import HashedBlockIO
@@ -111,8 +111,12 @@ class KDB4File(KDBFile):
         # file version is too high), the last 2 bytes are informational.
         # TODO implement version check
 
-        # the first header field starts at byte 12 after the signature
-        stream.seek(12)
+        # verify the file signature
+        signature = read_signature(stream)
+        assert signature == KDB4_SIGNATURE, signature
+
+        # read the file version
+        stream.read(4)
 
         while True:
             # field_id is a single byte

--- a/libkeepass/kdb4.py
+++ b/libkeepass/kdb4.py
@@ -47,6 +47,10 @@ class KDB4Header(HeaderDictionary):
         'StreamStartBytes': 9,
         # cipher used to protect data in xml (ARC4 or Salsa20)
         'InnerRandomStreamID': 10,
+        # KDBX 4, superseding Transform*
+        'KdfParameters': 11,
+        # KDBX 4
+        'PublicCustomData': 12,
     }
 
     fmt = {3: '<I', 6: '<q', 10: '<I'}

--- a/libkeepass/kdb4.py
+++ b/libkeepass/kdb4.py
@@ -22,6 +22,7 @@ from libkeepass.utils.merge import KDB4UUIDMerge
 
 KDB4_SALSA20_IV = bytes(bytearray.fromhex('e830094b97205d2a'))
 KDB4_SIGNATURE = (0x9AA2D903, 0xB54BFB67)
+FILEVERSION_4 = 0x00040000
 
 
 class KDB4Header(HeaderDictionary):
@@ -106,7 +107,8 @@ class KDB4File(KDBFile):
         # KeePass 2.07 has version 1.01,
         # 2.08 has 1.02,
         # 2.09 has 2.00, 2.10 has 2.02, 2.11 has 2.04,
-        # 2.15 has 3.00.
+        # 2.15 has 3.00, 2.20 has 3.01.
+        # By 2.38 KeePass will use version 4.00 if certain conditions are true.
         # The first 2 bytes are critical (i.e. loading will fail, if the
         # file version is too high), the last 2 bytes are informational.
         # TODO implement version check
@@ -116,7 +118,7 @@ class KDB4File(KDBFile):
         assert signature == KDB4_SIGNATURE, signature
 
         # read the file version
-        stream.read(4)
+        self.file_version = stream_unpack(stream, None, 4, 'I')
 
         while True:
             # field_id is a single byte
@@ -127,7 +129,10 @@ class KDB4File(KDBFile):
                 raise IOError('Unknown header field found.')
 
             # two byte (short) length of field data
-            length = stream_unpack(stream, None, 2, 'h')
+            if self.file_version < FILEVERSION_4:
+                length = stream_unpack(stream, None, 2, 'H')
+            else:
+                length = stream_unpack(stream, None, 4, 'I')
             if length > 0:
                 data = stream_unpack(stream, None, length, '{}s'.format(length))
                 self.header.b[field_id] = data
@@ -137,13 +142,16 @@ class KDB4File(KDBFile):
                 self.header_length = stream.tell()
                 break
 
+        if self.file_version >= FILEVERSION_4:
+            raise NotImplementedError("File version 4 support currently unimplemented.")
+
     def _header(self):
         # serialize header to stream
         header = bytearray()
         # write file signature
         header.extend(struct.pack('<II', *KDB4_SIGNATURE))
         # and version
-        header.extend(struct.pack('<hh', 1, 3))
+        header.extend(struct.pack('<I', self.file_version))
 
         field_ids = list(self.header.keys())
         field_ids.sort()
@@ -152,8 +160,14 @@ class KDB4File(KDBFile):
             value = self.header.b[field_id]
             length = len(value)
             header.extend(struct.pack('<b', field_id))
-            header.extend(struct.pack('<h', length))
+            if self.file_version < FILEVERSION_4:
+                header.extend(struct.pack('<H', length))
+            else:
+                header.extend(struct.pack('<I', length))
             header.extend(struct.pack('{}s'.format(length), value))
+
+        if self.file_version >= FILEVERSION_4:
+            raise NotImplementedError("File version 4 support currently unimplemented.")
 
         return header
 

--- a/libkeepass/utils/convert.py
+++ b/libkeepass/utils/convert.py
@@ -156,6 +156,7 @@ def convert_kdb3_to_kdb4(kdb3):
         raise IOError('Unsupported encryption type: %s'%ciphername)
     
     kdb4 = libkeepass.kdb4.KDB4Reader()
+    kdb4.file_version = 0x00030001
     kdb4.header.EndOfHeader = b'\r\n\r\n'
     #~ kdb4.header.Comment = 
     kdb4.header.CipherID = cipherid
@@ -167,7 +168,7 @@ def convert_kdb3_to_kdb4(kdb3):
     kdb4.header.EncryptionIV = os.urandom(16)
     kdb4.header.ProtectedStreamKey = os.urandom(32)
     kdb4.header.StreamStartBytes = os.urandom(32)
-    kdb4.header.InnerRandomStreamID = 2
+    kdb4.header.InnerRandomStreamID = 2 # Salsa20
     
     kdb4.keys = kdb3.keys[:]
     kdb4.in_buffer = io.BytesIO(lxml.etree.tostring(kxml4))

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
                 "2.x (v4) files",
     license="GPL",
     keywords="keepass library",
-    url="https://github.com/phpwutz/libkeepass",  # project home page, if any
+    url="https://github.com/libkeepass/libkeepass",  # project home page, if any
     test_suite="tests",
     install_requires=[
         "lxml>=3.2.1",


### PR DESCRIPTION
Various minor improvements. The main change is to correctly identify KDBX v4 files and throw and exception before fully parsing. There is code to read the header, but not fully parse all header items (`KdfParameters` and `PublicCustomData`).  Before this the code would error on an unknown field.